### PR TITLE
Fix configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,12 @@ AC_SEARCH_LIBS([strlcpy], [bsd])
 AS_IF([test "x$ac_cv_search_strlcpy" = "x-lbsd"], [AC_CHECK_HEADERS([bsd/string.h])])
 AC_CHECK_FUNCS([strlcpy])
 
+# check if bsd/string.h needs to be included
+dnl Check for the bsd/string.h header
+AC_CHECK_HEADER([bsd/string.h],
+  [AC_DEFINE([HAVE_BSD_STRING_H], [1], [Define if you have <bsd/string.h>])]
+)
+
 # Need the math library
 AC_CHECK_LIB([m],[sin])
 


### PR DESCRIPTION
On arch linux, this project did not compile due to 

  CC       libpal_la-palDfltin.lo
palDfltin.c: In function 'palDfltin':
palDfltin.c:185:3: error: implicit declaration of function 'strlcpy'; did you mean 'strncpy'? [-Wimplicit-function-declaration]
  185 |   strlcpy( tempbuf, &(string[*nstrt-1]), sizeof(tempbuf) );
      |   ^~~~~~~
      |   strncpy

After some debugging, the issue seems that HAVE_BSD_STRING_H was never set and thus the include never happens.